### PR TITLE
Updated duplicity.service

### DIFF
--- a/duplicity.service
+++ b/duplicity.service
@@ -6,8 +6,6 @@ After=docker.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-Restart=on-failure
-RestartSec=5
 
 ExecStartPre=-/usr/bin/docker rm -f %p
 ExecStart=/usr/bin/docker run --rm -t \


### PR DESCRIPTION
Service file won't work with timer due to has Restart= setting other than no, which isn't allowed for Type=oneshot services

I found this through google when trying to get a good systemd file for my duplicity setup. I guess that happens to others as well and I just spend over 2hrs debugging why I couldn't start the timer when it turns out that the service file is broken.
